### PR TITLE
Fix dark theme transition on reload

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, createContext } from "react";
+import { useState, useMemo, useEffect, useCallback, createContext } from "react";
 
 import PubNub from "pubnub";
 // pubnubKeys.js is listed in .gitignore, contains private keys
@@ -57,9 +57,23 @@ function App() {
   // Site Properties
 
   const [theme, setTheme] = useLocalState("theme", themes.light);
+  const [themeToggled, setThemeToggled] = useState(null);
+
   function toggleTheme() {
     setTheme(theme.type === "light" ? themes.dark : themes.light);
+    setThemeToggled(true);
   }
+
+  useEffect(() => {
+    document.body.style.transition = 'all 0.75s ease-in';
+    document.body.style.transitionProperty = 'background, color';
+
+    return () => {
+      document.body.style.transition = 'none';
+      document.body.style.transitionProperty = 'none';
+    }
+
+  }, [themeToggled])
 
   const [usingGradient, setUsingGradient] = useLocalState("gradients", "all");
   const [soundIsOn, setSoundIsOn] = useLocalState("sound", true);

--- a/src/GlobalStyle.js
+++ b/src/GlobalStyle.js
@@ -1,13 +1,9 @@
 import { createGlobalStyle } from "styled-components";
 
-// PROBLEM: TODO: THEME: in dark mode on refresh, it transitions from light mode
-
 const GlobalStyle = createGlobalStyle`
   body {
       background: ${({ theme }) => theme.background};
       color: ${({ theme }) => theme.foreground};
-      transition: all 0.75s ease-in;
-      transition-property: background, color
     }
   `;
 


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

Fixes #2 

Hi there! I came across this issue and have a fix - by only adding the transition to the body style at the moment that the theme toggle button is used (and then cleaning it up and setting it back to null on unmount ... ie page reload), you can prevent the transition effect from happening on reload and ensure it only happens when the button is used to toggle the theme. So, there is no longer a 0.75s transition from light to dark if dark mode is stored locally.  

I tried recording the improvement as a gif but... turns out it's not very interesting - nothing happens when the dark theme page reloads. 😆 